### PR TITLE
Fix: Chrome new restriction on cross domain requests

### DIFF
--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -3,14 +3,14 @@
 
   "name": "Fuel Cost for Google Maps™",
   "description": "Find out your gas usage before you hit the road with this extension for Google Maps™.",
-  "version": "1.0",
+  "version": "1.1",
 "permissions": [
   "https://fuelcostmapextension.appspot.com/*",
   "storage",
   "gcm"
 ],
 "background": {
-      "scripts": ["script/background.js"],
+      "scripts": ["vendor/jquery-3.3.1.min.js","script/background.js"],
       "persistent": false
   },
 
@@ -33,5 +33,4 @@
   "icons": {
 	"128": "images/gas-station-final.png" 
 	}
-
 }

--- a/Client/script/background.js
+++ b/Client/script/background.js
@@ -5,6 +5,29 @@ chrome.runtime.onInstalled.addListener(function (details) {
 	}
 });
 
+//Chrome no longer allows content scripts to send cross domain requests.
+//Instead, make the call here and send back the response to the content script.
+chrome.runtime.onConnect.addListener(function(port) {
+  console.assert(port.name == "request");
+  port.onMessage.addListener(function(msg) {
+		var reqPath = "?start=" + msg.start + "&end=" + msg.end + "&id=" + msg.id;
+		var req = $.ajax({
+					type : "GET",
+					url : "https://fuelcostmapextension.appspot.com/api/cost"
+							+ reqPath,
+					dataType : 'json'
+				});
+
+		var success = function(resp) {
+			port.postMessage({isSuccess:true, resp:resp});
+		}
+		var failure = function(resp) {
+			port.postMessage({isSuccess:false, resp:resp});
+		}
+		req.then(success, failure);
+  });
+});
+
 chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
     if (request.action == "openSettings")


### PR DESCRIPTION
https://www.chromium.org/Home/chromium-security/extension-content-script-fetches

Chrome has removed the ability for content scripts to send cross domain requests as an increased security measure. However, they do allow and encourage any cross domain requests to be made in the background script.

This change moves the one async call we do into the background script. A two way connection between the content script and the background script is made and the two interact with each other as follows:

- Content Script sends message to the background script with the request parameters.
- Background script receives the message and makes the actual ajax request.
- Background script sends back the response to the Content Script.
- Content script listens on the connection for responses and fires the appropriate callback as usual.

Essentially the background script now acts as a proxy for the end point we used to call since it is sending back the raw response from the ajax request.