### PR TITLE
Widget blocks newly introduced Google buttons

### DIFF
--- a/Client/css/main.css
+++ b/Client/css/main.css
@@ -1,6 +1,6 @@
 #rcmeWidget {
 	padding-left: 408px;
-	padding-top: 10px;
+	padding-top: 58px;
 }
 
 .menu-wrapper {

--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Fuel Cost for Google Maps™",
   "description": "Find out your gas usage before you hit the road with this extension for Google Maps™.",
-  "version": "1.1",
+  "version": "1.3",
 "permissions": [
   "https://fuelcostmapextension.appspot.com/*",
   "storage",

--- a/Client/script/background.js
+++ b/Client/script/background.js
@@ -1,6 +1,6 @@
 chrome.runtime.onInstalled.addListener(function (details) {
 	//Open settings page on first install or update
-	if(details.reason == "install" || details.reason == "update"){
+	if(details.reason == "install"){
 		chrome.runtime.openOptionsPage();
 	}
 });


### PR DESCRIPTION
Google introduced new buttons where our widget was originally position and as a result the buttons are blocked. This change shifts the widget down to avoid any blocking.

Before Googles Change (no buttons)
![main-640X400-2](https://user-images.githubusercontent.com/38227511/103243719-b0489b80-4928-11eb-888f-aa805fc74da0.png)

Widget shifted down with Googles new buttons:
![image](https://user-images.githubusercontent.com/38227511/103243863-349b1e80-4929-11eb-9550-6e00484a3727.png)
